### PR TITLE
getAuthFn/ auth_person uses getAuthFn()

### DIFF
--- a/lib/core/functions.inc.php
+++ b/lib/core/functions.inc.php
@@ -710,7 +710,9 @@ function collection( $model, $clause, $duration=null ) {
 		
 		will return an auth function that uses those contraints
 
-		key arguments for now only accept ['check_for_constant']
+		value arguments for now only accept ['constant']
+
+		KEYS MUST BE SET
 
 		constraints = array(
 			'arg1' => $vars, // check contants
@@ -751,9 +753,9 @@ function collection( $model, $clause, $duration=null ) {
 			$where = array();
 			foreach ($constraints as $constraint => $vars) {
 				if (!$params[$constraint]) {
-					if (!$vars['check_for_constant']) return false;
-					if (defined($vars['check_for_constant'])) {
-						$params[$constraint] = constant($vars['check_for_constant']);
+					if (!$vars['constant']) return false;
+					if (defined($vars['constant'])) {
+						$params[$constraint] = constant($vars['constant']);
 					}
 					if (!$params[$constraint]) return false;
 				}
@@ -824,7 +826,7 @@ function collection( $model, $clause, $duration=null ) {
 
 		$auth_fn = makeAuthFn(array(
 			'person_id' => array(
-				'check_for_constant' => 'PERSON_ID'
+				'constant' => 'PERSON_ID'
 			)
 		));
 

--- a/lib/core/functions.inc.php
+++ b/lib/core/functions.inc.php
@@ -747,11 +747,11 @@ function collection( $model, $clause, $duration=null ) {
 			// generate where, look for constants if check_for_constant is true and the params are not defined
 			// return false if it isn't set, exit early
 			$where = array();
-			foreach ($constraints as $constraint => $check_for_constant) {
+			foreach ($constraints as $constraint => $vars) {
 				if (!$params[$constraint]) {
-					if (!$check_for_constant) return false;
-					if (defined(strtoupper($constraint))) {
-						$params[$constraint] = constant(strtoupper($constraint));
+					if (!$vars['check_for_constant']) return false;
+					if (defined($vars['check_for_constant'])) {
+						$params[$constraint] = constant($vars['check_for_constant']);
 					}
 					if (!$params[$constraint]) return false;
 				}
@@ -821,7 +821,9 @@ function collection( $model, $clause, $duration=null ) {
 		if (!$person_id) $person_id = $_SESSION['login']['person_id'];
 
 		$auth_fn = makeAuthFn(array(
-			'person_id' => true
+			'person_id' => array(
+				'check_for_constant' => 'PERSON_ID'
+			)
 		));
 
 		return $auth_fn($access_level_str, $person_id);

--- a/lib/core/functions.inc.php
+++ b/lib/core/functions.inc.php
@@ -710,9 +710,11 @@ function collection( $model, $clause, $duration=null ) {
 		
 		will return an auth function that uses those contraints
 
+		key arguments for now only accept ['check_for_constant']
+
 		constraints = array(
-			'arg1' => true, // check contants
-			'arg2' => false // dont check for constant
+			'arg1' => $vars, // check contants
+			'arg2' => $vars // dont check for constant
 		);
 	*/
 


### PR DESCRIPTION
wrote a function that returns auth functions.

usage:

``` php

<?

function auth_person( $access_level_str, $person_id=NULL ) {

    $auth_fn = makeAuthFn(array(
        'person_id' => array(
            'constant' => 'PERSON_ID'
        )
    ));

    return $auth_fn($access_level_str, $person_id);

}

```

The `$constraints` array, the argument to `makeAuthFn` takes a key value pair of what the where criteria will be for the `$access_level_str`. The second paramater that the auth function accepts should generally be an array with keys matching the constraints, or empty, if there is one constraint, an array does not have to be used, the mapping happens automatically.
