### PR TITLE
Better parsing of AQL

### DIFF
--- a/lib/core/class.aql.php
+++ b/lib/core/class.aql.php
@@ -464,7 +464,7 @@ class aql {
 					$arr = aql2array::prepare_where($value, $aql_array[$table]['table']);
 					$clause_array[$table][$clause] = aql2array::check_where($arr, $aql_array[$table]['as']);
 				} else {
-					$value = (is_array($value)) ? $value : explode(',', $value);
+					$value = (is_array($value)) ? $value : splitOnComma($value);
 					$clause_array[$table][$clause] = aql2array::check_clause($value, $aql_array[$table], $aql_array[$table]['fields']);
 				}
 				

--- a/lib/core/class.aql.php
+++ b/lib/core/class.aql.php
@@ -464,7 +464,7 @@ class aql {
 					$arr = aql2array::prepare_where($value, $aql_array[$table]['table']);
 					$clause_array[$table][$clause] = aql2array::check_where($arr, $aql_array[$table]['as']);
 				} else {
-					$value = (is_array($value)) ? $value : splitOnComma($value);
+					$value = (is_array($value)) ? $value : explodeOnComma($value);
 					$clause_array[$table][$clause] = aql2array::check_clause($value, $aql_array[$table], $aql_array[$table]['fields']);
 				}
 				

--- a/lib/core/class.aql2array.php
+++ b/lib/core/class.aql2array.php
@@ -263,7 +263,7 @@ class aql2array {
 				if (is_string($clause) && preg_match('/(case|when)/mi', $clause)) {
 					$array[$k] = self::parse_case_when($clause, $table);
 				} else {
-					$cl = splitOnWhitespace($clause);
+					$cl = explodeOnWhitespace($clause);
 					foreach ($cl as $i => $c) {
 						if (!in_array($c, self::$comparisons) 
 							&& !empty($c) 
@@ -478,7 +478,7 @@ class aql2array {
 		}
 		
 		$i = 1;
-		$fields = splitOnComma($aql);
+		$fields = explodeOnComma($aql);
 		array_walk($fields, function($field, $_, $o) use($parent, &$tmp, &$i){
 			
 			$add_field = function($alias, $value, $type = 'fields') use(&$tmp) {
@@ -541,7 +541,7 @@ class aql2array {
 
 		foreach (array('order by', 'group by') as $cl) {
 			$tmp[$cl] = $this->check_clause(
-				splitOnComma($tmp[$cl]),
+				explodeOnComma($tmp[$cl]),
 				$parent,
 				array_merge($tmp['fields'], $tmp['aggregates'])
 			);

--- a/lib/core/class.model.php
+++ b/lib/core/class.model.php
@@ -109,7 +109,7 @@ class model implements ArrayAccess {
 			$do_set = $aql;
 			$aql = null;
 		}
-		
+
 		return array($aql, $do_set, $config);
 	}
 
@@ -585,7 +585,7 @@ class model implements ArrayAccess {
 
 /**
 	
-	@function 	rereshCache
+	@function 	refreshCache
 	@return 	(model) object
 	@param 		(identifier)
 

--- a/lib/core/functions.inc.php
+++ b/lib/core/functions.inc.php
@@ -129,6 +129,81 @@
 		return $text;
 	}
 
+	/**
+	 * makes a mini state machine that splits on the given $delimiter
+	 * @param string -> a delimiter (exampes: ',' or ' ')
+	 * @return function
+	 */
+	function explodeOnFn($delimiter) {
+		
+		// open => close (what matches what)
+		$closings = array(
+			'(' => ')',
+			"'" => "'",
+			'"' => '"'
+		);
+
+		return function($str) use($delimiter, $closings) {
+
+			$inner = array(); 		// stack of state
+			$escape_next = false;	// whether or not we're escaping the next character
+			$re = array();			// response
+
+			// init pieces
+			$split_str = str_split($str);
+			$length = count($split_str);
+
+			// current chunk
+			$current = '';
+			for ($i = 0; $i < $length; $i++) {
+				
+				$piece = $split_str[$i];
+
+				// escaping current if $escape_next
+				if ($escape_next) {
+					$current .= $piece;
+					$escape_next = false;
+					continue;
+				}
+
+				// if current $piece is delimiter and we're not in inner state, add to the split
+				if ($split_str[$i] == $delimiter && !$inner) {
+					$re[] = $current;
+					$current = '';
+					continue;
+				}
+
+				$current .= $piece;
+				
+				// match closings to this character push/pop state
+				foreach ($closings as $open => $close) {
+					if (end($inner) == $open && $piece == $close) {
+						array_pop($inner);
+					} else if ($piece == $open) {
+						array_push($inner, $piece);
+					}
+				}
+
+				$escape_next = ($piece == '\\');
+
+			} // end foreach character
+
+			// append the last piece
+			$re[] = $current;
+			return array_filter(array_map('trim', $re));
+		};
+	}
+
+	function splitOnComma($str) {
+		$fn = explodeOnFn(',');
+		return $fn($str);
+	}
+
+	function splitOnWhitespace($str) {
+		$fn = explodeOnFn(' ');
+		return $fn($str);
+	}
+
     // if_not( $a, $b )
     // shortcut for:
     // if (!$a) $a = $b;

--- a/lib/core/functions.inc.php
+++ b/lib/core/functions.inc.php
@@ -130,6 +130,7 @@
 	}
 
 	/**
+	 * It splits on tokens and fixes many AQL parsing issues with nested statements and commas/quotes inside of quotes
 	 * makes a mini state machine that splits on the given $delimiter
 	 * @param string -> a delimiter (exampes: ',' or ' ')
 	 * @param string -> string to split


### PR DESCRIPTION
function `split_on_comma` refactored to be generated by `explodeOnFn($delimiter)`

instead of `explode(' ')` for checking clauses (which is really unreliable), now using `splitOnWhitespace($str)`, also generated by `explodeOnFn()`

Corrects and issue where the order by was:

```
field = ''
```

and would be parsed as:

```
field = table.''
```
