### PR TITLE
page::inherit($path)

### DIFF
--- a/config.php
+++ b/config.php
@@ -29,6 +29,7 @@ $includes[] = 'lib/core/class.aql.php';
 $includes[] = 'lib/core/class.modelArrayObject.php';
 $includes[] = 'lib/core/class.model.php';
 $includes[] = 'lib/core/class.page.php';
+$includes[] = 'lib/core/class.SkyRouter.php';
 $includes[] = 'lib/adodb/adodb.inc.php';
 
 // needed by php 5.3

--- a/lib/core/class.SkyRouter.php
+++ b/lib/core/class.SkyRouter.php
@@ -1,5 +1,12 @@
 <?
 
+/*
+
+	$o = new SkyRouter($codebase_path_arr, $db);
+	$o->routePath('/newyork/newyearseve');
+
+*/
+
 class SkyRouter {
 	
 	public $configs = array();
@@ -21,11 +28,11 @@ class SkyRouter {
 
 	public function checkPath($qs, $prefix = null) {
 		$qs = array_filter($qs);
-		for ($i = $i + 1; $i <= count($qs); $i++) {
+		for ($i = 1; $i <= count($qs); $i++) {
 			$path_arr = array_slice($qs, 0, $i);
 			$slug = $path_arr[$i - 1];
 			$path = implode('/', $path_arr);
-			if ($path) $path = '/' . $path;
+			if ($path && $prefix) $path = '/' . $path;
 
 			$settings_file = $this->ft($prefix, $path, $slug, 'settings');
 			$script_file = $this->ft($prefix, $path, $slug, 'script');
@@ -52,7 +59,7 @@ class SkyRouter {
 					$tmp = $get_tmp($file);
 					if (!is_file($tmp)) continue;
 					if ($c === 'profile') {
-						if ($this->_checkProfile($qs[$i + 1], $i, $file, $tmp)) 
+						if ($this->_checkProfile($qs[$i], $i, $file, $tmp)) 
 							break 2;
 					} else {
 						$this->_addToPageAndPath($file, $tmp, $i);
@@ -75,7 +82,7 @@ class SkyRouter {
 
 			$path_arr = array_slice($qs, 0, $i - 1);
 			$path = implode('/', $path_arr);
-			if ($path) $path = '/' . $path;
+			if ($path && $prefix) $path = '/' . $path;
 
 			$maches = array();
 			foreach ($this->codebase_paths as $codebase_path) {

--- a/lib/core/class.SkyRouter.php
+++ b/lib/core/class.SkyRouter.php
@@ -2,7 +2,12 @@
 
 /*
 
-	$o = new SkyRouter($codebase_path_arr, $db);
+	$o = new SkyRouter(array(
+		'codebase_paths' => $codebase_paths,
+		'db' => $db,
+		'default_page' => $default,
+		'page_404' => 
+	));
 	$o->routePath('/newyork/newyearseve');
 
 */
@@ -16,10 +21,22 @@ class SkyRouter {
 	public $page_path = array();
 	public $db = null;
 	public $vars = array();
+	public $qs = array();
+	public $prefix = null;
+	public $is_default = false;
 
-	public function __construct($codebases, $db) {
-		$this->codebase_paths = $codebases;
-		$this->db = $db;
+	public function __construct($o = array()) {
+		
+		if (!$o) throw new Exception('Constructor arguments required.');
+		if (!is_assoc($o)) throw new Exception('Contsructor argument needs to be associative.');
+
+		$o = (object) $o;
+
+		$this->codebase_paths = $o->codebase_paths;
+		$this->db = $o->db;
+		$this->default_page = $o->default_page;
+		$this->page_404 = $o->page_404;
+
 	}
 
 	public function routePath($path) {
@@ -27,7 +44,11 @@ class SkyRouter {
 	}
 
 	public function checkPath($qs, $prefix = null) {
+		
 		$qs = array_filter($qs);
+		$this->qs = $qs;
+		$this->prefix = $prefix;
+
 		for ($i = $i + 1; $i <= count($qs); $i++) {
 			$path_arr = array_slice($qs, 0, $i);
 			$slug = $path_arr[$i - 1];
@@ -163,7 +184,7 @@ class SkyRouter {
 			}
 			if ($this->page[$i]) continue;
 		}
-		$i--;
+		
 	}
 
 	public function ft($prefix, $a, $b, $type) {
@@ -222,6 +243,13 @@ class SkyRouter {
 	private function _addToPageAndPath($file, $path, $key) {
 		$this->page[$key] = $path;
 		$this->page_path[$key] = $file;
+	}
+
+	public function checkPagePath($access_denied = false) {
+		if ($this->page_path || $access_denied) return false;
+		$add = (!$this->qs[1]) ? $this->default_page : $this->page_404;
+		$this->_addToPageAndPath($add, $add, 1);
+		return $this->is_default = (bool) (!$this->qs[1]);
 	}
 
 }

--- a/lib/core/class.SkyRouter.php
+++ b/lib/core/class.SkyRouter.php
@@ -105,7 +105,7 @@ class SkyRouter {
 			$path = implode('/', $path_arr);
 			if ($path && $prefix) $path = '/' . $path;
 
-			$maches = array();
+			$matches = array();
 			foreach ($this->codebase_paths as $codebase_path) {
 				$scandir = $codebase_path . $prefix . $path;
                 if (!is_dir($scandir)) continue;

--- a/lib/core/class.SkyRouter.php
+++ b/lib/core/class.SkyRouter.php
@@ -312,7 +312,7 @@ class SkyRouter {
 	public function checkPagePath() {
 		if ($this->page_path) return false;
 		$add = (!$this->qs[1]) ? $this->page_path_default : $this->page_path_404;
-		$this->_addToPageAndPath($add, $add, 1);
+		$this->addToPageAndPath($add, $add, 1);
 		return $this->is_default = (bool) (!$this->qs[1]);
 	}
 

--- a/lib/core/class.SkyRouter.php
+++ b/lib/core/class.SkyRouter.php
@@ -28,7 +28,7 @@ class SkyRouter {
 
 	public function checkPath($qs, $prefix = null) {
 		$qs = array_filter($qs);
-		for ($i = 1; $i <= count($qs); $i++) {
+		for ($i = $i + 1; $i <= count($qs); $i++) {
 			$path_arr = array_slice($qs, 0, $i);
 			$slug = $path_arr[$i - 1];
 			$path = implode('/', $path_arr);
@@ -59,7 +59,7 @@ class SkyRouter {
 					$tmp = $get_tmp($file);
 					if (!is_file($tmp)) continue;
 					if ($c === 'profile') {
-						if ($this->_checkProfile($qs[$i], $i, $file, $tmp)) 
+						if ($this->_checkProfile($qs[$i + 1], $i, $file, $tmp)) 
 							break 2;
 					} else {
 						$this->_addToPageAndPath($file, $tmp, $i);
@@ -111,7 +111,7 @@ class SkyRouter {
                 if (!$this->configs['database_folder']['numeric_slug'] || is_numeric($slug)) {
                 	$sql = "SELECT id FROM {$table} WHERE active = 1 and {$field} = '{$slug}'";
                 	if ($this->configs['database_folder']['where']) {
-                		$sql .= ' and ' . $this->config['database_folder']['where'];
+                		$sql .= ' and ' . $this->configs['database_folder']['where'];
                 	}
                 	elapsed($sql);
                 	$r = sql($sql);

--- a/lib/core/class.SkyRouter.php
+++ b/lib/core/class.SkyRouter.php
@@ -89,9 +89,9 @@ class SkyRouter {
 			$settings_file = $this->ft($prefix, $path, $slug, 'settings');
 			$script_file = $this->ft($prefix, $path, $slug, 'script');
 
-			$this->_includePreSettings();
-			$this->_includeToSettings($settings_file);
-			$this->_appendScript($script_file);
+			$this->includePreSettings();
+			$this->includeToSettings($settings_file);
+			$this->appendScript($script_file);
 
 			$check = array(
 				sprintf('%s%s.php',$prefix, $path) => true,
@@ -111,10 +111,10 @@ class SkyRouter {
 					$tmp = $get_tmp($file);
 					if (!is_file($tmp)) continue;
 					if ($c === 'profile') {
-						if ($this->_checkProfile($qs[$i + 1], $i, $file, $tmp)) 
+						if ($this->checkProfile($qs[$i + 1], $i, $file, $tmp)) 
 							break 2;
 					} else {
-						$this->_addToPageAndPath($file, $tmp, $i);
+						$this->addToPageAndPath($file, $tmp, $i);
 						break 2;
 					}
 				}
@@ -126,7 +126,7 @@ class SkyRouter {
 			}
 
 			if ($this->page[$i]) {
-				$this->_includePostSettings();
+				$this->includePostSettings();
 				continue;
 			}
 
@@ -156,8 +156,8 @@ class SkyRouter {
                 $settings_file = $this->dft($prefix, $path, $folder, 'settings');
                 $script_file = $this->dft($prefix, $path, $folder, 'script');
 
-                $this->_includePreSettings();
-                $this->_includeToSettings($settings_file);
+                $this->includePreSettings();
+                $this->includeToSettings($settings_file);
 
                 $lookup_id = null;
                 if (!$this->settings['database_folder']['numeric_slug'] || is_numeric($slug)) {
@@ -171,13 +171,14 @@ class SkyRouter {
                 	$r = null;
                 }
 
+                // clear database folder settings
                 $this->settings['database_folder'] = null;
                 
                 if ($lookup_id === null) {
                 	continue;
                 }
 
-                $this->_includePostSettings();
+                $this->includePostSettings();
                 $qs[$i] = $folder;
                 $lookup_field_id = $table . '_id';
                 $$lookup_field_id = $lookup_id;
@@ -185,7 +186,7 @@ class SkyRouter {
                 $lookup_slug = str_replace('.', '_', $field);
                 $$lookup_slug = $slug;
                 $this->vars[$lookup_slug] = $slug;
-                $this->_appendScript($script_file);
+                $this->appendScript($script_file);
 
                 $get_tmp = function($f) use($codebase_path) {
                 	return $codebase_path . $f;
@@ -201,10 +202,10 @@ class SkyRouter {
 					$tmp = $get_tmp($file);
 					if (!is_file($tmp)) continue;
 					if ($c === 'profile') {
-						if ($this->_checkProfile($qs[$i + 1], $i, $file, $tmp)) 
+						if ($this->checkProfile($qs[$i + 1], $i, $file, $tmp)) 
 							break 2;
 					} else {
-						$this->_addToPageAndPath($file, $tmp, $i);
+						$this->addToPageAndPath($file, $tmp, $i);
 						break 2;
 					}
 				}
@@ -235,24 +236,24 @@ class SkyRouter {
 	/*
 		add script to scripts array if file exists
 	*/
-	private function _appendScript($f) {
+	private function appendScript($f) {
 		if (!file_exists_incpath($f)) return;
 		$this->scripts[$f] = true;
 	}
 
-	private function _includePreSettings() {
-		$this->_includeToSettings('lib/core/hooks/settings/pre-settings.php');
+	private function includePreSettings() {
+		$this->includeToSettings('lib/core/hooks/settings/pre-settings.php');
 	}
 
-	private function _includePostSettings() {
-		$this->_includeToSettings('lib/core/hooks/settings/post-settings.php');
+	private function includePostSettings() {
+		$this->includeToSettings('lib/core/hooks/settings/post-settings.php');
 	}
 
 	/*
 		if the file exists, merges declared variables to $this->settings
 		using $__file__ because it is unlikely to appear in the settings file
 	*/
-	private function _includeToSettings($__file__) {
+	private function includeToSettings($__file__) {
 		if (!file_exists_incpath($__file__)) return;
 		include $__file__;
 		$vars = get_defined_vars();
@@ -266,7 +267,7 @@ class SkyRouter {
 		this method checks to see if there is a $primary_table 
 		and if this is an IDE/add-new for this $primary_table
 	*/
-	private function _checkProfile($piece, $i, $file, $path) {
+	private function checkProfile($piece, $i, $file, $path) {
 		
 		// find primary_table via model if it is specified
 		if ($this->settings['model']) {
@@ -286,7 +287,7 @@ class SkyRouter {
 		// set to profile
 		$decrypted = decrypt($piece, $this->settings['primary_table']);
 		if ($piece == 'add-new' || is_numeric($decrypted)) {
-			$this->_addToPageAndPath($file, $path, $i);
+			$this->addToPageAndPath($file, $path, $i);
 			return true;
 		}
 
@@ -300,7 +301,7 @@ class SkyRouter {
 		at the specified key
 		this is used if these files are found
 	*/
-	private function _addToPageAndPath($path, $file, $key) {
+	private function addToPageAndPath($path, $file, $key) {
 		$this->page[$key] = $file;
 		$this->page_path[$key] = $path;
 	}

--- a/lib/core/class.SkyRouter.php
+++ b/lib/core/class.SkyRouter.php
@@ -1,0 +1,220 @@
+<?
+
+class SkyRouter {
+	
+	public $configs = array();
+	public $codebase_paths = array();
+	public $scripts = array();
+	public $page = array();
+	public $page_path = array();
+	public $db = null;
+	public $vars = array();
+
+	public function __construct($codebases, $db) {
+		$this->codebase_paths = $codebases;
+		$this->db = $db;
+	}
+
+	public function routePath($path) {
+		return $this->checkPath(explode('/', $path), 'pages');
+	}
+
+	public function checkPath($qs, $prefix = null) {
+		$qs = array_filter($qs);
+		for ($i = $i + 1; $i <= count($qs); $i++) {
+			$path_arr = array_slice($qs, 0, $i);
+			$slug = $path_arr[$i - 1];
+			$path = implode('/', $path_arr);
+			if ($path) $path = '/' . $path;
+
+			$settings_file = $this->ft($prefix, $path, $slug, 'settings');
+			$script_file = $this->ft($prefix, $path, $slug, 'script');
+
+			$this->_includePreSettings();
+			$this->_includeToConfig($settings_file);
+			$this->_includeScript($script_file);
+
+			$check = array(
+				sprintf('%s%s.php',$prefix, $path) => true,
+				sprintf('%s%s/%s.php', $prefix, $path, $slug) => true,
+				$this->ft($prefix, $path, $slug, 'profile') => 'profile',
+				$this->ft($prefix, $path, $slug, 'listing') => true
+			);
+
+			foreach ($this->codebase_paths as $codebase_path) {
+
+				$file = '';
+				$get_tmp = function($f) use($codebase_path) {
+					return $codebase_path . $f;
+				};
+
+				foreach ($check as $file => $c) {
+					$tmp = $get_tmp($file);
+					if (!is_file($tmp)) continue;
+					if ($c === 'profile') {
+						if ($this->_checkProfile($qs[$i + 1], $i, $file, $tmp)) 
+							break 2;
+					} else {
+						$this->_addToPageAndPath($file, $tmp, $i);
+						break 2;
+					}
+				}
+
+				$file = $prefix . $path;
+				$tmp = $get_tmp($file);
+				if ($path && is_dir($tmp)) $this->page[$i] = 'directory';
+
+			}
+
+			if ($this->page[$i]) {
+				$this->_includePostSettings();
+				continue;
+			}
+
+			if (!$this->db) continue;
+
+			$path_arr = array_slice($qs, 0, $i - 1);
+			$path = implode('/', $path_arr);
+			if ($path) $path = '/' . $path;
+
+			$maches = array();
+			foreach ($this->codebase_paths as $codebase_path) {
+				$scandir = $codebase_path . $prefix . $path;
+                if (!is_dir($scandir)) continue;
+                foreach (scandir($scandir) as $filename) {
+                    if (substr($filename, 0, 1) != '_' || strlen($filename) <= 6) continue;
+                    if (substr($filename, -1) != '_') continue;
+                    if (!is_dir($scandir . '/' . $filename)) continue;
+                    $matches[substr($filename, 1, -1)] = $codebase_path;
+                }
+			}
+
+			if (!$matches) continue;
+
+			foreach ($matches as $field => $codebase_path) {
+				$folder = '_' . $field .'_';
+                $table = substr($field, 0, strpos($field, '.'));
+                $settings_file = $this->dft($prefix, $path, $folder, 'settings');
+                $script_file = $this->dft($prefix, $path, $folder, 'script');
+
+                $this->_includePreSettings();
+                $this->_includeToConfig($settings_file);
+
+                $lookup_id = null;
+                if (!$this->configs['database_folder']['numeric_slug'] || is_numeric($slug)) {
+                	$sql = "SELECT id FROM {$table} WHERE active = 1 and {$field} = '{$slug}'";
+                	if ($this->configs['database_folder']['where']) {
+                		$sql .= ' and ' . $this->config['database_folder']['where'];
+                	}
+                	elapsed($sql);
+                	$r = sql($sql);
+                	if (!$r->EOF) $lookup_id = $r->Fields('id');
+                	$r = null;
+                }
+
+                $this->configs['database_folder'] = null;
+                
+                if ($lookup_id === null) {
+                	continue;
+                }
+
+                $this->_includePostSettings();
+                $qs[$i] = $folder;
+                $lookup_field_id = $table . '_id';
+                $$lookup_field_id = $lookup_id;
+                $this->vars[$lookup_field_id] = $lookup_id;
+                $lookup_slug = str_replace('.', '_', $field);
+                $$lookup_slug = $slug;
+                $this->vars[$lookup_slug] = $slug;
+                $this->_includeScript($script_file);
+
+                $get_tmp = function($f) use($codebase_path) {
+                	return $codebase_path . $f;
+                };
+
+                $check = array(
+                	sprintf('%s%s/%s/%s.php', $prefix, $path, $folder, $folder) => true,
+                	$this->dft($prefix, $path, $folder, 'profile') => 'profile',
+                	$this->dft($prefix, $path, $folder, 'listing') => true
+                );
+
+                foreach ($check as $file => $c) {
+					$tmp = $get_tmp($file);
+					if (!is_file($tmp)) continue;
+					if ($c === 'profile') {
+						if ($this->_checkProfile($qs[$i + 1], $i, $file, $tmp)) 
+							break 2;
+					} else {
+						$this->_addToPageAndPath($file, $tmp, $i);
+						break 2;
+					}
+				}
+
+				$file = sprintf('%s%s/%s', $prefix, $path, $folder);
+				$tmp = $get_tmp();
+				if (is_dir($tmp)) $this->page[$i] = 'directory';
+			}
+			if ($this->page[$i]) continue;
+		}
+		$i--;
+	}
+
+	public function ft($prefix, $a, $b, $type) {
+		return sprintf('%s%s/%s-%s.php', $prefix, $a, $b, $type);
+	}
+
+	public function dft($prefix, $a, $b, $type) {
+		return sprintf('%s%s/%s/%s-%s.php', $prefix, $a, $b, $b, $type);
+	}
+
+	private function _checkPaths() { 
+
+	}
+
+	private function _includeScript($f) {
+		if (!file_exists_incpath($f)) return;
+		$this->scripts[$f] = true;
+	}
+
+	private function _includePreSettings() {
+		$this->_includeToConfig('lib/core/hooks/pre-settings.php');
+	}
+
+	private function _includePostSettings() {
+		$this->_includeToConfig('lib/core/hooks/settings/post-settings.php');
+	}
+
+	private function _includeToConfig($__file__) {
+		if (!file_exists_incpath($__file__)) return;
+		include $__file__;
+		$vars = get_defined_vars();
+		unset($vars['__file__']);
+		$this->configs = array_merge($this->configs, $vars);
+	}
+
+	private function _checkProfile($piece, $i, $file, $path) {
+		
+		if ($this->configs['model']) {
+			$this->configs['primary_table'] = aql::get_primary_table(aql::get_aql($this->configs['model']));
+		}
+
+		if ($this->configs['primary_table']) {
+			if ($piece == 'add-new' || is_numeric(decrypt($piece, $this->configs['primary_table']))) {
+				$this->_addToPageAndPath($file, $path, $i);
+				return true;
+			}
+		} else {
+			header("HTTP/1.1 503 Service Temporarily Unavailable");
+	        header("Status: 503 Service Temporarily Unavailable");
+	        header("Retry-After: 1");
+	        die("Profile Page Error:<br /><b>$file</b> exists, but <b>\$primary_table</b> is not specified in <b>$settings_file</b></div>");
+		}
+
+	}
+
+	private function _addToPageAndPath($file, $path, $key) {
+		$this->page[$key] = $path;
+		$this->page_path[$key] = $file;
+	}
+
+}

--- a/lib/core/class.page.php
+++ b/lib/core/class.page.php
@@ -382,7 +382,7 @@ class page {
         return (count($server) <= 2) ? null : $server[0];
     }
 
-    function inherit($path, $data = array()) {
+    function inherit($path, $__data__ = array()) {
         
         global $codebase_path_arr, $db;
         
@@ -396,9 +396,9 @@ class page {
 
         $router->checkPath(array_merge(explode('/', $path), $this->queryfolders));
         
-        $path = end($router->page_path);
+        $__path__ = end($router->page_path);
 
-        if (!$path) {
+        if (!$__path__) {
             throw new Exception('page::inherit could not find this path. ');
         }
     
@@ -407,7 +407,7 @@ class page {
         $this->css[] = $this->page_css;
         $this->page_css = $this->page_js = null;
 
-        $prefixed = str_replace(array('-profile', '-listing'), null, $path);
+        $prefixed = str_replace(array('-profile', '-listing'), null, $__path__);
         $prefixed = substr($prefixed, 0, -4);
 
         $css = $prefixed . '.css';
@@ -416,12 +416,12 @@ class page {
         if (file_exists_incpath($css)) $this->page_css = '/' . $css;
         if (file_exists_incpath($js)) $this->page_js = '/' . $js;
 
-        unset($router, $prefixed, $css, $js);
-        foreach ($data as $k => $v) $$k = $v;
-        unset($data);
+        unset($router, $prefixed, $css, $js, $path);
+        foreach ($__data__ as $k => $v) $$k = $v;
+        unset($__data__);
         
         $p = $this;
-        include $path;
+        include $__path__;
 
     }
 

--- a/lib/core/class.page.php
+++ b/lib/core/class.page.php
@@ -387,7 +387,7 @@ class page {
         @param (associative array) $data
         
         creates the effect of a symlink and allows the passing of data (keys of $data)
-        to the included page to mimic the directory structure of $path
+        to the included page to mimic the directory contents of $path
 
         $p->inherit('includes/somepath');
 

--- a/lib/core/class.page.php
+++ b/lib/core/class.page.php
@@ -435,7 +435,7 @@ class page {
         $lastkey = array_pop(array_keys($router->page_path));
         $sliced = array_slice($router->qs, 0, $lastkey);
         $this->urlpath = '/' . implode('/', $sliced);
-        $this->incpath = ($this->incpath) ?: sprintf('%s/%s', $router->prefix, $sliced);
+        $this->incpath = ($this->incpath) ?: sprintf('%s/%s', $router->prefix, implode('/', $sliced));
         $this->page_path = end($router->page_path);
         $this->queryfolders = array_slice($router->qs, $lastkey);
         $this->querystring = $_SERVER['QUERY_STRING'];

--- a/lib/core/class.page.php
+++ b/lib/core/class.page.php
@@ -382,4 +382,36 @@ class page {
         return (count($server) <= 2) ? null : $server[0];
     }
 
+    function inherit($path, $data = array()) {
+        
+        global $codebase_path_arr, $db;
+        
+        $router = new SkyRouter($codebase_path_arr, $db);
+        $router->checkPath(array_merge(explode('/', $path), $this->queryfolders));
+        
+        $this->vars = array_merge($this->vars, $router->vars);
+        $this->js[] = $this->page_js;
+        $this->css[] = $this->page_css;
+        $this->page_css = $this->page_js = null;
+
+        $path = end($router->page_path);
+        $prefixed = str_replace(array('-profile', '-listing'), null, $path);
+        $prefixed = substr($prefixed, 0, -4);
+
+        $css = $prefixed . '.css';
+        $js = $prefixed . '.js';
+
+        if (file_exists_incpath($css)) $this->page_css = '/' . $css;
+        if (file_exists_incpath($js)) $this->page_js = '/' . $js;
+
+        unset($router, $prefixed, $css, $js);
+        foreach ($data as $k => $v) $$k = $v;
+        unset($data);
+        
+        // krumo($router);
+        $p = $this;
+        include $path;
+
+    }
+
 }//class page

--- a/lib/core/class.page.php
+++ b/lib/core/class.page.php
@@ -151,17 +151,17 @@ class page {
         if ( $this->no_template ) return $this;
 
         if ($this->page_path == 'pages/default/default.php' && $template_area == 'top') {
-            $hometop = $this->_get_template_contents($template_name, 'hometop');
+            $hometop = $this->get_template_contents($template_name, 'hometop');
             if ($hometop) {
                 echo $hometop;
                 return $this;
             }
         }
-        echo $this->_get_template_contents($template_name, $template_area);
+        echo $this->get_template_contents($template_name, $template_area);
         return $this;
     }
 
-    private function _get_template_contents($template_name, $template_area) {
+    private function get_template_contents($template_name, $template_area) {
         $p = $this;
         ob_start();
         include ( 'templates/' . $template_name . '/' . $template_name . '.php');

--- a/sky.php
+++ b/sky.php
@@ -290,11 +290,7 @@ if ( $access_denied ) {
     }
     
     //print_r($_POST);
-
-    $page_css_file = substr(str_replace(array('-profile','-listing'),null,end($page_path)),0,-4) . '.css';
-    $page_js_file = substr(str_replace(array('-profile','-listing'),null,end($page_path)),0,-4) . '.js';
-    if ( file_exists_incpath($page_css_file) ) $p->page_css = '/' . $page_css_file;
-    if ( file_exists_incpath($page_js_file) ) $p->page_js = '/' . $page_js_file;
+    $p->setAssetsByPath(end($page_path));
 
     // if ajax refreshing a secondary div after an ajax state change
     if ( $_POST['_p'] ) {

--- a/sky.php
+++ b/sky.php
@@ -227,19 +227,19 @@ if(!$no_cookies){
 $router = new SkyRouter(array(
     'codebase_paths' => $codebase_path_arr,
     'db' => $db,
-    'page_404' => $page_404,
-    'default_page' => $default_page
+    'page_path_404' => $page_404,
+    'page_path_default' => $default_page
 ));
 
 $router->checkPath($sky_qs, 'pages');
 
-// configs to global :/
-foreach ($router->configs as $k => $v) $$k = $v;
+// settings to global :/
+foreach ($router->settings as $k => $v) $$k = $v;
 
 // user authentication (uses $access_groups from $router->configs)
 include 'lib/core/hooks/login/authenticate.php';
 
-$p->setPropertiesByRouter($router, $access_denied);
+$p->setPropertiesByRouter($router);
 $p->sky_start_time = $sky_start_time;
 $p->protocol = $_SERVER['HTTPS'] ? 'https' : 'http';
 

--- a/sky.php
+++ b/sky.php
@@ -224,220 +224,16 @@ if(!$no_cookies){
 
 }
 
+$router = new SkyRouter($codebase_path_arr, $db);
+$router->checkPath($sky_qs, 'pages');
 
-// check each folder slug in the url to find the deepest page match
-for ( $i=$i+1; $i<=count($sky_qs); $i++ ) {
-    $path_arr = array_slice( $sky_qs, 0, $i );
-    #print_a($path_arr);
-    $slug = $path_arr[$i-1];
-    $path = implode('/',$path_arr);
-    if ( $path ) $path = '/' . $path;
-    $settings_file = 'pages' . $path . '/' . $slug . '-settings.php';
-    $script_file = 'pages' . $path . '/' . $slug . '-script.php';
-    //echo 'fsettings: '.$settings_file . '<br />';
-    include('lib/core/hooks/settings/pre-settings.php');
-    if ( file_exists_incpath($settings_file)) include_once $settings_file;
-    if ( file_exists_incpath($script_file) ) {
-        //include_once( $script_file );
-        $script_files[ $script_file ] = true;
-    }
+$script_files = $router->scripts;
+$page = $router->page;
+$page_path = $router->page_path;
 
-    foreach ( $codebase_path_arr as $codebase_path ) {
+// configs to global :/
+foreach ($router->configs as $k => $v) $$k = $v;
 
-        $file = 'pages' . $path . '.php';
-        if ( is_file( $codebase_path . $file ) ) {
-            $page[$i] = $codebase_path . $file;
-            $page_path[$i] = $file;
-            break;
-        }
-
-        $file = 'pages' . $path . '/' . $slug . '.php';
-        if ( is_file( $codebase_path . $file ) ) {
-            $page[$i] = $codebase_path . $file;
-            $page_path[$i] = $file;
-            break;
-        }
-
-        $file = 'pages' . $path . '/' . $slug . '-profile.php';
-        if ( is_file( $codebase_path . $file ) ) {
-            if ( $model ) {
-                $primary_table = aql::get_primary_table( aql::get_aql($model) );
-            }
-            if ( $primary_table ) {
-                //echo "slug: $slug<br />";
-                //print_a($sky_qs);
-                if ( $sky_qs[$i+1] == 'add-new' || is_numeric( decrypt($sky_qs[$i+1],$primary_table) ) ) {
-                    $page[$i] = $codebase_path . $file;
-                    $page_path[$i] = $file;
-                    break;
-                }
-            } else {
-                header("HTTP/1.1 503 Service Temporarily Unavailable");
-                header("Status: 503 Service Temporarily Unavailable");
-                header("Retry-After: 1");
-                die("Profile Page Error:<br /><b>$file</b> exists, but <b>\$primary_table</b> is not specified in <b>$settings_file</b></div>");
-            }
-        }
-
-        $file = 'pages' . $path . '/' . $slug . '-listing.php';
-        if ( is_file( $codebase_path . $file ) ) {
-            $page[$i] = $codebase_path . $file;
-            $page_path[$i] = $file;
-            break;
-        }
-
-        $file = 'pages' . $path;
-        if ( $path && is_dir( $codebase_path . $file ) ) {
-            $page[$i] = 'directory';
-        }
-    }
-    if ( $page[$i] ) {
-        $post_settings = 'lib/core/hooks/settings/post-settings.php';
-        if ( file_exists_incpath($post_settings)) include($post_settings);
-        continue;
-    }
-
-    // look for database folders
-    if ( $db ) {
-        // set the path back to the last path, so we can scan for a db folder match
-        $path_arr = array_slice( $sky_qs, 0, $i-1 );
-        //print_a($path_arr);
-        $path = implode('/',$path_arr);
-        if ( $path ) $path = '/' . $path;
-        // check if we have a database folder cached for this uri path
-        $cache_match = null;
-        $matches = array();
-        if ( !$_GET['refresh'] && false) { // disabled
-            $cache_match = mem("skyphp:dbfolder:$path/$slug");
-            #print_a($cache_match);
-            if ( $cache_match ) {
-                $matches = array( $cache_match['field'] => $cache_match['codebase_path'] );
-            }
-        }
-        #print_a($matches);
-        #echo $path;
-        // if not cached, scan all codebases to test every possible _db.folder_
-        if ( !$matches ) {
-            foreach ( $codebase_path_arr as $codebase_path ) {
-                $scandir = $codebase_path . 'pages' . $path;
-                //debug("scandir=$scandir<br />");
-                if ( is_dir( $scandir ) ) {
-                    foreach ( scandir( $scandir ) as $filename ) {
-                        if ( substr($filename,0,1)=='_' && strlen($filename) > 6 ) {
-                            if ( is_dir( $scandir . '/' . $filename ) ) {
-                                if ( substr($filename,-1)=='_' ) {
-                                    //debug("folder=$filename<br />");
-                                    $matches[ substr($filename,1,-1) ] = $codebase_path;
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        }
-        #print_a($matches);
-        if ( $matches ) {
-            foreach ( $matches as $field => $codebase_path ) {
-                $folder = '_' . $field . '_';
-                //debug($folder . ' is a database folder.<br />');
-                $table = substr( $field, 0, strpos( $field, '.' ) );
-                //debug("path=$path<br />");
-                //echo 'path: ' . $path . '<br />';
-                $settings_file = 'pages' . $path . '/' . $folder .'/' . $folder . '-settings.php';
-                $script_file = 'pages' . $path . '/' . $folder .'/' . $folder . '-script.php';
-                //echo 'dbsettings: '.$settings_file."<br />";
-                include('lib/core/hooks/settings/pre-settings.php');
-                if ( file_exists_incpath($settings_file)) include( $settings_file );
-                // don't include post-settings unless this is a match
-                $lookup_id = null;
-                if ( $cache_match ) { 
-                    $lookup_id = $cache_match['id'];
-                } else if ( !$database_folder['numeric_slug'] || is_numeric( $slug ) ) {
-                    $SQL = "select id
-                            from $table
-                            where active = 1 and $field = '$slug'";
-                    if ( $database_folder['where'] ) {
-                        $SQL .= ' and ' . $database_folder['where'];
-                    }
-                    elapsed($SQL);
-                    //debug($SQL . '<br />');
-                    $r = sql($SQL);
-                    if ( !$r->EOF ) {
-                        $lookup_id = $r->Fields('id');
-                        // cache the database folder we found at this uri
-                        mem("skyphp:dbfolder:{$_SERVER['HTTP_HOST']}:$path/$slug",array(
-                            'id' => $lookup_id,
-                            'field' => $field,
-                            'codebase_path' => $codebase_path
-                        ));
-                    }
-                    elapsed('end sql');
-                }
-                $database_folder = NULL;
-                if ( $lookup_id !== null ) {
-                    include('lib/core/hooks/settings/post-settings.php');
-                    //debug('DATABASE MATCH!<br />');
-
-                    $sky_qs[$i] = $folder;
-                    $lookup_field_id = $table . '_id';
-                    $$lookup_field_id = $lookup_id;
-                    $p->vars[$lookup_field_id] = $lookup_id;
-                    $lookup_slug = str_replace('.','_',$field);
-                    $$lookup_slug = $slug;
-                    $p->vars[$lookup_slug] = $slug;
-
-                    if ( file_exists_incpath($script_file) ) {
-                        // include( $script_file );
-                        $script_files[ $script_file ] = true;
-                    }
-
-                    $file = 'pages' . $path . '/' . $folder . '/' . $folder . '.php';
-                    if ( is_file( $codebase_path . $file ) ) {
-                        $page[$i] = $codebase_path . $file;
-                        $page_path[$i] = $file;
-                        break;
-                    }
-
-                    $file = 'pages' . $path . '/' . $folder . '/' . $folder . '-profile.php';
-                    if ( is_file( $codebase_path . $file ) ) {
-                        if ( $model ) {
-                            $primary_table = aql::get_primary_table( aql::get_aql($model) );
-                        }
-                        if ( $primary_table ) {
-                            //echo "slug: $slug<br />";
-                            //print_a($sky_qs);
-                            if ( $sky_qs[$i+1] == 'add-new' || is_numeric( decrypt($sky_qs[$i+1],$primary_table) ) ) {
-                                $page[$i] = $codebase_path . $file;
-                                $page_path[$i] = $file;
-                                break;
-                            }
-                        } else {
-                            header("HTTP/1.1 503 Service Temporarily Unavailable");
-                            header("Status: 503 Service Temporarily Unavailable");
-                            header("Retry-After: 1");
-                            die("Profile Page Error:<br /><b>$file</b> exists, but <b>\$primary_table</b> is not specified in <b>$settings_file</b></div>");
-                        }
-                    }
-
-                    $file = 'pages' . $path . '/' . $folder . '/' . $folder . '-listing.php';
-                    if ( is_file( $codebase_path . $file ) ) {
-                        $page[$i] = $codebase_path . $file;
-                        $page_path[$i] = $file;
-                        break;
-                    }
-
-                    $file = 'pages' . $path . '/' . $folder;
-                    if ( is_dir( $codebase_path . $file ) ) {
-                        $page[$i] = 'directory';
-                    }
-                }//if
-                $r = NULL;
-            }//foreach
-            if ( !$page[$i] ) continue;
-        }// if lookup fields
-    }//if $db
-}//check forward
-$i--;
 
 // user authentication
 include('lib/core/hooks/login/authenticate.php');
@@ -448,7 +244,7 @@ include('lib/core/hooks/login/authenticate.php');
 #print_a($page);
 
 // default page or page not found 404
-if ( !is_array($page_path) && !$access_denied ) {
+if ( (!is_array($page_path) || !$page_path) && !$access_denied ) {
     if ($sky_qs_original[1]) $page[1] = $page_path[1] = $page_404;
     else {
         $page[1] = $page_path[1] = $default_page;

--- a/sky.php
+++ b/sky.php
@@ -230,10 +230,10 @@ $router->checkPath($sky_qs, 'pages');
 $script_files = $router->scripts;
 $page = $router->page;
 $page_path = $router->page_path;
+$p->vars = $router->vars;
 
 // configs to global :/
 foreach ($router->configs as $k => $v) $$k = $v;
-
 
 // user authentication
 include('lib/core/hooks/login/authenticate.php');
@@ -265,6 +265,8 @@ $p->ide = $p->queryfolders[count($p->queryfolders)-1];
 $p->sky_start_time = $sky_start_time;
 $p->protocol = $_SERVER['HTTPS'] ? 'https' : 'http';
 
+// vars into global scope for backwards compatibility
+foreach ($p->vars as $k => $v) $$k = $v;
 
 // set constants
 define( 'URLPATH', $p->urlpath );


### PR DESCRIPTION
Added the ability for a page to inherit from another page.

---
#### Example:

``` php
<?

// in path -- pages/user/user.php
$p->inherit('includes/user');


// ---------------- //

// in path -- pages/admin/user
$p->inherit('includes/user', array('is_admin' => true));

```

If the requested page is `/user/343/songs` and the path `includes/user/_user.id_/songs/songs.php` exists, it will use that as the `page`. Also `/admin/user/343/songs` would use the same inherited page.

Can also pass `$data` to the inherited page wich should be an associative array that will be pushed into the page's scope by:

``` php
<?

foreach ($__data__ as $k => $v) $$k = $v;
unset($__data__, $k, $v);

```
