### PR TITLE
Added loadDB to delete()

### DIFF
--- a/lib/core/class.Model.php
+++ b/lib/core/class.Model.php
@@ -545,6 +545,10 @@ class Model implements ArrayAccess {
 			$fields['mod__person_id'] = $fields['update__person_id'] = PERSON_ID;
 		}
 
+		// load the object 
+		// so that we have the information left over for after_delete hooks
+		$this->loadDB($id);
+
 		if ($this->methodExists('before_delete')) {
 			$this->before_delete();
 		}


### PR DESCRIPTION
In `before_delete` and `after_delete` as well as `$_belongs_to` triggers, we need to have the object's data to use.

During the delete, normally all that is posted is the object identifier and token, these hooks fail because the object does not have the data except for what is posted during this process.

This fixes that issue.
