### PR TITLE
sky.post tweak

### DIFF
--- a/lib/js/sky.utils.js
+++ b/lib/js/sky.utils.js
@@ -161,6 +161,12 @@ var sky = (function() {
 
     var post = function(url, data, fn) {
 
+        // allow for post(url, fn)
+        if (typeof data === 'function' && typeof fn === 'undefined') {
+            fn = data;
+            data = null;
+        }
+
         data = data || {};
         fn = fn || function() { };
 

--- a/lib/js/sky.utils.js
+++ b/lib/js/sky.utils.js
@@ -277,7 +277,9 @@ var sky = (function() {
     // if it fails, we return def
     var parseJSON = function(value, def) {
 
-        var p, def = def || {};
+        def = def || {};
+        var p;
+
         if (typeof value == 'object') return value;
         try         { p = $.parseJSON(value); }
         catch(e)    { p = def; }
@@ -324,7 +326,7 @@ var aql = {
         if (typeof pars != 'object') return null;
 
         url = this._postHelpers.makeUrl(pars, errormsg, def);
-        pars.SuccessMessage = pars.successMessage || 'Saved.';
+        pars.successMessage = pars.successMessage || 'Saved.';
         return this._postHelpers.post(pars, url);
 
     },
@@ -452,7 +454,7 @@ var linkedSelects = {
     }
 };
 
-(function(jQuery) {
+(function() {
 
     jQuery.fn.aqlSave = function(model, data, callbacks) {
         if (!callbacks) callbacks = {};
@@ -529,4 +531,4 @@ var linkedSelects = {
         });
     };
 
-})(jQuery);
+})();


### PR DESCRIPTION
``` js

var url = "/abc",
    data = { a: 1 },
    callback = function(response) { 
        console.log(response); 
    };

// used to be that in order to not send data 
// you needed to send a null param
sky.post(url, null, callback);

// added support for this:
sky.post(url, callback);
```
