### PR TITLE
Model loading tweak

### DIFF
--- a/lib/class/class.Model.php
+++ b/lib/class/class.Model.php
@@ -1694,7 +1694,6 @@ class Model implements ArrayAccess {
                 $this->tableMakeProperties($table);
                 $i++;
             }
-            unset($i);
         } else {
             $e = sprintf(self::E_INVALID_MODEL, $this->_model_name);
             if (!is_ajax_request()) {
@@ -2097,8 +2096,11 @@ class Model implements ArrayAccess {
      *  @param mixed $sub
      */
     public function tableMakeProperties($table, $sub = null) {
+
         if (is_array($table['objects'])) foreach ($table['objects'] as $k => $v) {
-            $this->addProperty($k)->$k = array();
+            if (!$this->propertyExists($k)) {
+                $this->addProperty($k)->$k = array();
+            }
             $this->_objects[$k] = ($v['plural']) ? 'plural' : true;
         }
 
@@ -2108,7 +2110,9 @@ class Model implements ArrayAccess {
         }
 
         if (is_array($table['subqueries'])) foreach($table['subqueries'] as $k => $v) {
-            $this->addProperty($k)->$k = array();
+            if (!$this->propertyExists($k)) {
+                $this->addProperty($k)->$k = array();
+            }
         }
 
         $this->addProperty($table['table'].'_id');

--- a/lib/class/class.Model.php
+++ b/lib/class/class.Model.php
@@ -1782,12 +1782,15 @@ class Model implements ArrayAccess {
         }
 
         $o = $this;
+
         $load = function($m) use($o, $use_dbw) {
             if (!Model::isModelClass($m) || !$m->_id) return;
             $m->_force_db = false;
+            $m->_getModelAql()->makeProperties();
             $m->loadDB($m->_id, $o->_force_db, $use_dbw);
             $m->construct();
         };
+
         $isPlural = function($type) {
             return ($type === 'plural');
         };


### PR DESCRIPTION
Instead of only using `$model->_properties` stored in cache with the object, when a model making sure the sub objects are not outdated, it uses the currently defined model's AQL statement.

This cuts down on data compatibility issues when a model has changed (a field is added or removed) and a method is added that uses this field.

---

This is one step in the direction of _NOT_ storing object metadata in the cache (only `$model->_data`, `$model->_cached_time`) and greatly decreasing the size, and lazy loading our information.
## Example:
#### Old AQL:

```
artist {
    name
}
```
#### New AQL:

```
artist {
   name,
   [artist_album]s as albums
}
```
#### Behavior:

``` php
<?php

$artist = new artist($some_id);

# added [artist_album]s to model definition, but didn't refresh the object
# old behavior: Model::mapSubObjects() throws an error 
# because the field is not defined to be a plural subobject

$albums = $artist->mapSubObjects('albums', $callback); 

# new behavior, this property is added as it is created 
# (although the data would still eventually have to be refreshed)
```
