### PR TITLE
convertTo*() methods

### DIFF
--- a/lib/class/class.Model.php
+++ b/lib/class/class.Model.php
@@ -914,6 +914,86 @@ class Model implements ArrayAccess
             : new Model($id, $str);
     }
 
+    /**
+     *  Returns an object based on the argument $o
+     *  @param  mixed   $o
+     *  @return Model
+     *  @throws ModelNotFoundException if cannot find the model
+     */
+    public static function convertToObject($o)
+    {
+        if (self::isModelClass($o)) {
+            return $o;
+        }
+
+        $cl = get_called_class();
+        $obj = new $cl($o);
+
+        if (!$obj->getID()) {
+            throw new ModelNotFoundException('Model object not found');
+        }
+
+        return $obj;
+    }
+
+    /**
+     *  Returns an ID based on the argument $o
+     *  @param  mixed   $o
+     *  @return string
+     *  @throws \Exception if cannot find the ID
+     */
+    public static function convertToID($o)
+    {
+        if (is_numeric($o)) return $o;
+        if (self::isModelClass($o)) {
+            $id = $o->getID();
+            if (!$id) {
+                throw new Exception('Paramter is an empty object');
+            }
+            return $id;
+        }
+
+        $cl = get_called_class();
+        $tmp = new $cl;
+        $tbl = $tmp->getPrimaryTable();
+
+        $id = decrypt($o, $tbl);
+        if (!$id) {
+            throw new Exception('ID not found.');
+        }
+        return $id;
+    }
+
+    /**
+     *  Returns an IDE based on the argument $o
+     *  @param  mixed   $o
+     *  @return string
+     *  @throws \Exception if cannot find the IDE or it is invalid
+     */
+    public static function convertToIDE($o)
+    {
+        if (self::isModelClass($o)) {
+            $ide = $o->getIDE();
+            if (!$ide) {
+                throw new Exception('Parameter is an empty object.');
+            }
+            return $ide;
+        }
+
+        $cl = get_called_class();
+        $tmp = new $cl;
+        $tbl = $tmp->getPrimaryTable();
+
+        if (is_numeric($o)) {
+            return encrypt($o, $tbl);
+        }
+
+        $id = decrypt($o, $tbl);
+        if (!$id) {
+            throw new Exception('IDE not found.');
+        }
+        return $o;
+    }
 
     /**
      *  Does not check the cache for the object,


### PR DESCRIPTION
Not sure about the name for these methods but these would be useful methods:
- `Model::convertToObject($mixed)`
- `Model::convertToID($mixed)`
- `Model::convertToIDE($mixed)`
## Examles:

``` php
<?php
/**
 * @var $unknown, but we want an aritst object
 */
try {
    $artist = artist::convertToObject($unknown);
} catch (Exception $e) {
    // failed :(
}
```

If `$unknown` was an artist object, it would return itself, if it was an ID/IDE, it would create a new one. If the object is empty, an exception is thrown.

The methods `convertToID()` and `convertToIDE()` are similar, they take the shortest route to getting each of these values, and throw exceptions on failure.
