### PR TITLE
Model validation and some AQL updates

### DIFF
--- a/lib/class/class.Model.php
+++ b/lib/class/class.Model.php
@@ -1307,6 +1307,7 @@ class Model implements ArrayAccess
      *  @param  array   $clause             clause array
      *  @param  Boolean $do_count           if true, returns a count of the list
      *  @return array
+     *  @todo   use \getList class with field names for args as well
      */
     public static function getList($clause = array(), $do_count = false)
     {

--- a/lib/class/class.Model.php
+++ b/lib/class/class.Model.php
@@ -960,7 +960,7 @@ class Model implements ArrayAccess
      */
     public function startTransaction()
     {
-        $this->getMasterDB()->startTrans();
+        $this->getMasterDB()->StartTrans();
         return $this;
     }
 
@@ -2181,6 +2181,7 @@ class Model implements ArrayAccess
             return $this->errorResponse();
         }
 
+        // store these values because after the save there will be an ID
         $is_insert = $this->isInsert();
         $is_update = $this->isUpdate();
 
@@ -2237,7 +2238,7 @@ class Model implements ArrayAccess
 
         return ($failed || $this->_errors)
             ? $this->_handleSaveFailure($save_array)
-            : $this->_handleSaveSuccess($save_array, $is_insert, $is_update);
+            : $this->_handleSaveSuccess($save_array, $is_insert);
     }
 
     /**
@@ -2264,14 +2265,10 @@ class Model implements ArrayAccess
     /**
      *  @param  array   $save_array
      *  @param  Boolean $is_insert
-     *  @param  Boolean $is_update
      *  @return array
      */
-    protected function _handleSaveSuccess(
-        $save_array,
-        $is_insert = false,
-        $is_update = false
-    ) {
+    protected function _handleSaveSuccess($save_array, $is_insert = false)
+    {
         if ($this->methodExists('before_reload')) {
             $this->before_reload();
         }
@@ -2283,7 +2280,7 @@ class Model implements ArrayAccess
             if ($this->methodExists('after_insert')) $this->after_insert();
         }
 
-        if ($is_update) {
+        if (!$is_insert) {
             if ($this->methodExists('after_update')) $this->after_update();
         }
 

--- a/lib/sh/create-model.sh
+++ b/lib/sh/create-model.sh
@@ -32,7 +32,8 @@ touch $1/class.$1.php
 echo - writing class definition
 echo -n "<?php
 
-class $1 extends Model {
+class $1 extends Model
+{
 
     /**
      *  @var array
@@ -56,7 +57,10 @@ class $1 extends Model {
      *  runs as a construct hook, do not override __construct()
      *  also gets executed after Model::reload()
      */
-    public function construct() { }
+    public function construct()
+    {
+
+    }
 
     ######################################################################################
     ## These hooks are \"surrounding\" Model::validate()                                ##
@@ -67,30 +71,53 @@ class $1 extends Model {
     /**
      *  runs before standard validation
      */
-    public function preValidate() { }
+    public function preValidate()
+    {
+
+    }
 
     /**
      *  runs after standard validation if there are no errors
      */
-    public function postValidate() { }
+    public function postValidate()
+    {
+
+    }
 
     ######################################################################################
     ## These hooks are executed after validating if there are no errors                 ##
     ######################################################################################
 
-    public function before_insert() { }
+    public function before_insert()
+    {
 
-    public function after_insert() { }
+    }
 
-    public function before_update() { }
+    public function after_insert()
+    {
 
-    public function after_update() { }
+    }
 
-    public function before_delete() { }
+    public function before_update()
+    {
 
-    public function after_delete() { }
+    }
 
-        
+    public function after_update()
+    {
+
+    }
+
+    public function before_delete()
+    {
+
+    }
+
+    public function after_delete()
+    {
+
+    }
+
 }
 
 " > $1/class.$1.php


### PR DESCRIPTION
- wrap validation in a transaction as well
- validation will not run set_field methods for fields that already have errors
- validation will only break on the steps if we are using string errors, not ValidationErrors (bc)
- refactored global $dbw so that dependency is in only one place
- Model::addInternalError() and static $internal_errors so these are consistent with $possible_errors
- getByClause/getMany/getOne now use getList()
