### PR TITLE
memcache keys with $db_name prefix if it is set. Closes #112

### DIFF
--- a/lib/Sky/Api.php
+++ b/lib/Sky/Api.php
@@ -418,9 +418,12 @@ abstract class Api
      */
     public function wrap($data, $resource_class, $action)
     {
-        if (!$data && $data !== false) throw new Api\NotFoundException(
-            'The requested resource has no data.'
-        );
+        if (!$data && $data !== false) {
+            throw new Api\NotFoundException(
+                'The requested resource has no data.'
+            );
+        }
+
         $action_info = $resource_class::getAction($action);
         if (!isset($action_info['response_key'])) {
             // if response_key is not set, wrapper defaults to method alias

--- a/lib/Sky/Memcache.php
+++ b/lib/Sky/Memcache.php
@@ -278,7 +278,7 @@ class Memcache
     {
 
         if (!static::isMemcacheEnabled() || !$key) {
-            return false;
+            return;
         }
 
         $m = static::getMemcache();

--- a/lib/class/class.Model.php
+++ b/lib/class/class.Model.php
@@ -1706,8 +1706,9 @@ class Model implements ArrayAccess
     }
 
     /**
-     * @param mixed $id    identifier(id, ide), default: $this->getID()
-     * @return string
+     * @param   mixed       $id    identifier(id, ide), default: $this->getID()
+     * @return  string
+     * @global  $db_name
      */
     public function getMemKey($id = null)
     {
@@ -1720,7 +1721,10 @@ class Model implements ArrayAccess
             ? ':v' . strtotime($this::$mod_time)
             : null;
 
-        return $this->_model_name . ':loadDB' . $v . ':' . $id;
+        global $db_name;
+        $prefix = ($db_name) ? $db_name . ':' : '';
+
+        return $prefix . $this->_model_name . ':loadDB' . $v . ':' . $id;
     }
 
     /**


### PR DESCRIPTION
Since the mem function supports multi get internally, added a multi-delete wrapper as well.

``` php
<?php

$keys = array('test1', 'test2', 'test3');

foreach ($keys as $k) {
    mem($k, md5(mt_rand()));
}

var_dump(mem($keys));
/*
array(3) {
  ["test1"]=>
  string(32) "d65fa2048a0771885892a557d5586729"
  ["test2"]=>
  string(32) "3a7200a76df04ede94cf030e813619b9"
  ["test3"]=>
  string(32) "9e0a18a2fcd5a6aec5a06266b818887b"
}
*/

mem($keys, null);

var_dump(mem($keys));
/*
array(3) {
  ["test1"]=>
  NULL
  ["test2"]=>
  NULL
  ["test3"]=>
  NULL
}
*/
```
