### PR TITLE
fix parse issue

### DIFF
--- a/lib/class/class.aql2array.php
+++ b/lib/class/class.aql2array.php
@@ -18,7 +18,7 @@ class aql2array
      * Flag for if caching aqlarrays
      * @var Boolean
      */
-    public static $use_mem = false;
+    public static $use_mem = true;
 
     /**
      * Cache duration

--- a/lib/class/class.aql2array.php
+++ b/lib/class/class.aql2array.php
@@ -18,7 +18,7 @@ class aql2array
      * Flag for if caching aqlarrays
      * @var Boolean
      */
-    public static $use_mem = true;
+    public static $use_mem = false;
 
     /**
      * Cache duration
@@ -343,13 +343,13 @@ class aql2array
     {
         $field = trim($field);
         if (strpos($field, '\'') !== false ||
+            strpos($field, '.') !== false ||
             in_array($field, self::$comparisons) ||
             is_numeric($field) ||
             $table_name == $field
         ) {
             return $field;
         }
-
         if (strpos($field, '(') !== false ||
             strpos($field, ')') !== false
         ) {
@@ -366,6 +366,11 @@ class aql2array
         $f = '';
         foreach ($rf as $r) {
             $r = trim($r);
+
+            if ($table_name . '_id' == $r) {
+                $r = 'id';
+            }
+
             if ($r) {
                 if (strpos($r,'.') === false
                     && !in_array(trim($r), self::$comparisons)
@@ -841,7 +846,6 @@ class aql2array
                 }
             } else {
 
-                // regular field
                 $add_field($alias, trim($o->add_table_name($parent['as'], $as[0])));
             }
 
@@ -979,6 +983,7 @@ class aql2array
         return array_map(function($where) use($table, $find_matches) {
 
             $matches = $find_matches($where);
+
             $field = $matches['field'][0];
             if (empty($field)) {
                 return $where;


### PR DESCRIPTION
```
table {
   name
   where table_id = 1
}
```

now runs as

```
select id as table_id, name from table where table.id = 1
```

instead of

```
select id as table_id, name from table where table.table_id = 1
```
