### PR TITLE
Updates

### DIFF
--- a/lib/Sky/Api/Resource.php
+++ b/lib/Sky/Api/Resource.php
@@ -173,6 +173,22 @@ abstract class Resource
     }
 
     /**
+     * Returns an associative array of this objects publicly accesible properties
+     * Casting to array returns private/protected properties with * prefixes
+     * @return array
+     */
+    public function dataToArray()
+    {
+        $d = (array) $this;
+        foreach ($d as $k => $v) {
+            if ($k[1] == '*') {
+                unset($d[$k]);
+            }
+        }
+        return $d;
+    }
+
+    /**
      * Adds an error to the error stack ($this->errors)
      * @param string $message error message
      */

--- a/lib/class/class.Model.php
+++ b/lib/class/class.Model.php
@@ -1580,9 +1580,12 @@ class Model implements ArrayAccess
      */
     public static function isModelClass($class)
     {
-        if (!is_object($class) && (is_numeric($class) || !trim($class))) {
+        if (!is_object($class) &&
+            (is_numeric($class) || (is_string($class) && !trim($class)))
+        ) {
             return false;
         }
+
         try {
             $ref = new ReflectionClass($class);
 


### PR DESCRIPTION
- `Sky\Api\Resource::dataToArray()` consistent with Model.
- `Model::isModelClass()` wont trim non-strings.
