### PR TITLE
fix duplicate param issue

### DIFF
--- a/lib/Sky/Api.php
+++ b/lib/Sky/Api.php
@@ -244,8 +244,9 @@ abstract class Api
                 // so get the entire object
                 // create the instance and return the data
 
+                $key = $this->singular($resource_name);
                 return $this->response->setOutput(array(
-                    $this->singular($resource_name) => $makeInstance()
+                    $key => $this->getResource($class, $params)
                 ));
 
             }
@@ -279,17 +280,21 @@ abstract class Api
                         );
                     }
 
-                    // get the output of the method
-                    $output = $makeInstance()->$method($params);
+                    // instantiate the resource and get the output of the method
+                    $output = $this->getResource($class, array(
+                        'id' => $id
+                    ))->$method($params);
+
                     // wrap the output in a var key if applicable
                     $output = static::wrap($output, $class, $aspect);
                     return $this->response->setOutput($output);
 
                 } else {
+                    // presumably we are requesting a valid property of the resource
 
                     // need to have an instance here in order to check the properties
                     // which are added at instantiation
-                    $o = $makeInstance();
+                    $o = $this->getResource($class, $params);
 
                     if (!property_exists($o, $aspect)) {
                         throw new Api\NotFoundException(
@@ -365,6 +370,18 @@ abstract class Api
 
         $response->errors = array($error);
         return $response;
+    }
+
+    /**
+     * Gets the specified Resource instance
+     * @param string $class
+     * @param array $params
+     * @param Identity $identity
+     * @return Resource
+     */
+    protected function getResource($class, $params)
+    {
+        return new $class($params, $this->identity);
     }
 
     /**

--- a/lib/Sky/Api.php
+++ b/lib/Sky/Api.php
@@ -227,13 +227,6 @@ abstract class Api
 
             $id = $qf[1];
             $params['id'] = $id;
-            $identity = $this->identity;
-
-            // function go generate the instance
-            // we dont do this here becuase requested data/aspect may be invalid
-            $makeInstance = function() use($class, $params, $identity) {
-                return new $class($params, $identity);
-            };
 
             // now that we have our instance, either return it or return the aspects
             // being requested

--- a/lib/Sky/Api.php
+++ b/lib/Sky/Api.php
@@ -226,7 +226,6 @@ abstract class Api
             }
 
             $id = $qf[1];
-            $params['id'] = $id;
 
             // now that we have our instance, either return it or return the aspects
             // being requested
@@ -236,6 +235,8 @@ abstract class Api
                 // no aspect is being requested
                 // so get the entire object
                 // create the instance and return the data
+
+                $params['id'] = $id;
 
                 $key = $this->singular($resource_name);
                 return $this->response->setOutput(array(
@@ -287,6 +288,7 @@ abstract class Api
 
                     // need to have an instance here in order to check the properties
                     // which are added at instantiation
+                    $params['id'] = $id;
                     $o = $this->getResource($class, $params);
 
                     if (!property_exists($o, $aspect)) {
@@ -386,8 +388,6 @@ abstract class Api
     protected function getMethodName($resource_class, $action)
     {
         $action_info = $resource_class::getAction($action);
-        // sometimes we don't know if the method exists or not.. don't throw exception
-        if (!$action_info) return false;
         return $action_info['method'] ?: static::toCamelCase($action);
     }
 


### PR DESCRIPTION
The issue is when accessing an API Resource, ix: /api/v1/orders/12345/action with params, the array of arguments from post get passed both to __construct() and action().
