### PR TITLE
Aql cleanup

### DIFF
--- a/lib/Sky/AQL/TransactionException.php
+++ b/lib/Sky/AQL/TransactionException.php
@@ -54,7 +54,6 @@ class TransactionException extends Exception
         $this->id = $id;
         $this->type = $this->getTransactionType();
         $this->db_error = $db->ErrorMsg();
-        // $this->sql = $this->getSQL($db);
 
         parent::__construct($this->makeMessage());
     }
@@ -71,25 +70,6 @@ class TransactionException extends Exception
         }
 
         return (is_array($this->fields)) ? 'update' : 'increment';
-    }
-
-    /**
-     * Gets the SQL from the insert / update
-     * we can only auto generate the sql in this scenario
-     * @param   ADODB $db
-     * @return  string
-     */
-    private function getSQL($db)
-    {
-        if ($this->type == 'increment') {
-            return;
-        }
-
-        $id = $this->id ?: -1;
-        $m = $this->type == 'udpate' ? 'GetUpdateSQL' : 'GetInsertSQL';
-        $rs = $db->Execute("SELECT * FROM {$this->table} WHERE id = {$id}");
-
-        return $db->$m($rs, $this->fields) ?: '[no valid fields to ' . $this->type .']';
     }
 
     /**

--- a/lib/Sky/AQL/TransactionException.php
+++ b/lib/Sky/AQL/TransactionException.php
@@ -54,7 +54,7 @@ class TransactionException extends Exception
         $this->id = $id;
         $this->type = $this->getTransactionType();
         $this->db_error = $db->ErrorMsg();
-        $this->sql = $this->getSQL($db);
+        // $this->sql = $this->getSQL($db);
 
         parent::__construct($this->makeMessage());
     }

--- a/lib/class/class.Model.php
+++ b/lib/class/class.Model.php
@@ -886,7 +886,7 @@ class Model implements ArrayAccess
         foreach ($arr as $k => $v) {
             if ($this->_objects[$k] === 'plural') {
                 foreach ($v as $i => $o) {
-                    if (self::isModelClass($o)) {
+                    if (is_object($o) && self::isModelClass($o)) {
                         $return[$k][$i] = $o->dataToArray($hide_ids);
                     }
                 }


### PR DESCRIPTION
Remove `getSQL` from transactionExceptions, ADODB likes to print its own errors in output.
