### PR TITLE
ModelArrayObject fix.

### DIFF
--- a/lib/class/class.aql.php
+++ b/lib/class/class.aql.php
@@ -657,7 +657,7 @@ class aql {
 						if ($object) $tmp[$k][] = $o;
 						else $tmp[$k][] = $o->dataToArray();
 					}
-				} else if (!$s['plural'] && $arg) {
+				} else if (!$s['plural']) {
 					$arg = (int) $tmp[$s['constructor argument']];
 					$o = Model::get($m, $arg, $sub_do_set);
 					if ($object) {


### PR DESCRIPTION
Fix loading empty objects.

This creates empty `Model` objects for properties that are not loaded.
Currently, they are set as `ModelArrayObject`, which is wrong.
