### PR TITLE
getList improvements and bug fixes

### DIFF
--- a/lib/class/class.getList.php
+++ b/lib/class/class.getList.php
@@ -538,7 +538,6 @@ class getList
                         'operator' => ($search_operators) ? $op : null,
                         'callback' => function($val) use($lst, $fields, $field) {
                             $where = \getList::prepVal(\getList::csvToArray($val));
-                            print_pre($where);
                             $lst->where[] = "{$field} in {$where}";
                         }
                     );

--- a/lib/class/class.getList.php
+++ b/lib/class/class.getList.php
@@ -350,7 +350,7 @@ class getList
         }
 
         $q = $this->params['search'];
-        $qs = array_map('trim', explode(',', $q));
+        $qs = array_map('trim', explode(';', $q));
 
         $operators = array_values($this->filters);
 
@@ -394,7 +394,7 @@ class getList
      */
     private function _matchSearchOperators($search)
     {
-        preg_match('/^(?<operator>[\w]+):(?<search>.+)$/', $search, $matches);
+        preg_match('/^(?<operator>[\w]+):\s*(?<search>.+)$/', $search, $matches);
         return $matches;
     }
 
@@ -532,10 +532,11 @@ class getList
         $lst = new self;
         $lst->setAQL($min_aql)
             ->defineFilters(array_map(
-                function($field) use($lst, $search_operators) {
+                function($field) use($lst, $search_operators, $fields) {
+                    $op = array_search($field, $fields);
                     return array(
-                        'operator' => ($search_operators) ? $field : null,
-                        'callback' => function($val) use($lst, $field) {
+                        'operator' => ($search_operators) ? $op : null,
+                        'callback' => function($val) use($lst, $fields, $field) {
                             $where = \getList::prepVal($val);
                             $lst->where[] = "{$field} in {$where}";
                         }

--- a/lib/class/class.getList.php
+++ b/lib/class/class.getList.php
@@ -537,7 +537,8 @@ class getList
                     return array(
                         'operator' => ($search_operators) ? $op : null,
                         'callback' => function($val) use($lst, $fields, $field) {
-                            $where = \getList::prepVal($val);
+                            $where = \getList::prepVal(\getList::csvToArray($val));
+                            print_pre($where);
                             $lst->where[] = "{$field} in {$where}";
                         }
                     );
@@ -546,6 +547,19 @@ class getList
             ));
 
         return $lst;
+    }
+
+    /**
+     * If argument is a string, it explodes on comma
+     * using \explodeOn because of strings that look like `",", "b"` (quoted commas)
+     * @param   mixed   $param
+     * @return  array
+     */
+    public static function csvToArray($param)
+    {
+        return (is_string($param))
+            ? array_filter(array_map('trim', \explodeOn(',', $param)))
+            : $param;
     }
 
     /**


### PR DESCRIPTION
### Updates:
- serach operator `,` -> `;`
- allows for search ors, as a CSV
- allow whitespace between operator and term "name: Stan" not works
- fix operators for auto generated search filters
- csvToArray uses `explodeOn` instead of `explode` in case a search has "," in it
### Example:

``` php
<?php

$aql = "artist { name }"; // assume label is a string
$list = \getList::autoGenerate($aql, true); // bool true creates search operators as well

$ids = $list->select(array(
    'search' => 'name: Metallica, Queen, The Roots'
));

$ids; // array(1, 2, 3)
```
